### PR TITLE
acinclude.m4: fix build with autoconf >= 2.72

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1426,8 +1426,8 @@ ac_cv_stacksetup_$1='guessed:(skaddr),(sksize)'
 ])
 dnl #   restore original compile environment
 CFLAGS="$OCFLAGS"
-])dnl
 fi
+])dnl
 dnl #   extract result ingredients of single cached result value
 type=`echo $ac_cv_stacksetup_$1 | sed -e 's;:.*$;;'`
 addr=`echo $ac_cv_stacksetup_$1 | sed -e 's;^.*:;;' -e 's;,.*$;;'`


### PR DESCRIPTION
Move `fi` statement where it belongs to fix the following build failure with autoconf >= 2.72:
```
checking for stack setup via makecontext... ./configure: line 15863: syntax error near unexpected token `;;'
```

Fixes:
 - http://autobuild.buildroot.org/results/013e0d3f72582ce3675f65786c014518682d703b